### PR TITLE
Fixed some bugs

### DIFF
--- a/giwifi-gear.sh
+++ b/giwifi-gear.sh
@@ -214,10 +214,7 @@ gw_auth_token() {
 #############################################
 init() {
 	# check dep
-	if ! [ -x "$(command -v curl)" ]; then
-		echo 'Error: curl is not installed.' >&2
-		exit 1
-	fi
+	hash curl 2>/dev/null || { echo 'Error: curl is not installed.' >&2; exit 1; }
 
 # set default ua
 	AUTH_UA=$PC_UA

--- a/giwifi-gear.sh
+++ b/giwifi-gear.sh
@@ -30,7 +30,7 @@ url_encode() {
 
 	local length="${#1}"
 	for i in $(seq $length); do
-		local c="${1:$i-1:1}"
+		local c="${1:$((i-1)):1}"
 		case $c in
 		[a-zA-Z0-9.~_-]) printf '%s' "$c" ;;
 		*) printf '%%%02X' "'$c" ;;


### PR DESCRIPTION
### fix url_encode() bug
**Fix URL encoding bug in old version bash (operation is wronglyconsidered as string splicing)**
### check dep through hash
**`hash` supports more environments than `command`**  

> hash foo 2>/dev/null: works with Z shell (Zsh), Bash, Dash and ash.
> type -p foo: it appears to work with Z shell, Bash and ash (BusyBox), but not Dash (it interprets -p as an argument).
> command -v foo: works with Z shell, Bash, Dash, but not ash (BusyBox) (-ash: command: not found).
> Also note that builtin is not available with ash and Dash.
> Reference link: [https://stackoverflow.com/a/24856148](https://stackoverflow.com/a/24856148)
